### PR TITLE
Reverse alias and faster keyify

### DIFF
--- a/StatCounter.py
+++ b/StatCounter.py
@@ -134,10 +134,7 @@ for line in file:
 			for poke in battle[player]['team']:
 				#annoying alias shit
 				species = poke['species']
-				for alias in aliases:
-					if species in aliases[alias]:
-						species = alias
-						break
+				species = reverseAliases.get(species, species)
 
 				team.append(species)
 
@@ -201,10 +198,7 @@ for line in file:
 					continue
 				species = leads[i]
 				#annoying alias shit
-				for alias in aliases:
-					if species in aliases[alias]:
-						species = alias
-						break
+				species = reverseAliases.get(species, species)
 				if species not in leadCounter['raw'].keys():
 					leadCounter['raw'][species]=0.0
 					leadCounter['weighted'][species]=0.0

--- a/batchLogReader.py
+++ b/batchLogReader.py
@@ -129,21 +129,15 @@ def getTeamsFromLog(log,mrayAllowed):
 			if species[0] in string.lowercase or species[1] in string.uppercase:
 				species = species.title()
 
-			for s in aliases: #combine appearance-only variations and weird PS quirks
-				if species in aliases[s]:
-					species = s
-					break
+			species = reverseAliases.get(species, species) #combine appearance-only variations and weird PS quirks
 			try:	
 				species=keyLookup[keyify(species)]
 			except:
 				sys.stderr.write(species+' not in keyLookup.\n')
 				return False
 
-			for s in aliases: #this 2nd one is needed to deal with Nidoran
-				if species in aliases[s]:
-					species = s
-					break
-			
+			species = reverseAliases.get(species, species) #this 2nd one is needed to deal with Nidoran
+
 			teams[team].append({
 				'species': species,
 				'nature': nature,
@@ -373,10 +367,7 @@ def LogReader(filename,tier,movesets,ratings):
 				# remove gender
 				species = species.split(',')[0]
 
-				for s in aliases: #combine appearance-only variations and weird PS quirks
-					if species in aliases[s]:
-						species = s
-						break
+				species = reverseAliases.get(species, species) #combine appearance-only variations and weird PS quirks
 
 				try:
 					active[0]=ts.index([ts[0][0],species])
@@ -423,10 +414,7 @@ def LogReader(filename,tier,movesets,ratings):
 				# remove gender
 				species = species.split(',')[0]
 
-				for s in aliases: #combine appearance-only variations and weird PS quirks
-					if species in aliases[s]:
-						species = s
-						break	
+				species = reverseAliases.get(species, species) #combine appearance-only variations and weird PS quirks
 
 				try:
 					active[1]=ts.index([ts[11][0],species])
@@ -603,10 +591,7 @@ def LogReader(filename,tier,movesets,ratings):
 				# remove gender
 				species = species.split(',')[0]
 
-				for s in aliases: #combine appearance-only variations and weird PS quirks
-					if species in aliases[s]:
-						species = s
-						break
+				species = reverseAliases.get(species, species) #combine appearance-only variations and weird PS quirks
 
 				if [ts[11*(int(line[p])-1)][0],species] not in ts:
 					if species == 'Shaymin' and [ts[11*(int(line[p])-1)][0],'Shaymin-Sky'] in ts:
@@ -710,10 +695,7 @@ def LogReader(filename,tier,movesets,ratings):
 				species = species.split(',')[0]
 				while ',' in species:
 					species = species[0:string.rfind(species,',')]
-				for s in aliases: #combine appearance-only variations and weird PS quirks
-					if species in aliases[s]:
-						species = s
-						break
+				species = reverseAliases.get(species, species) #combine appearance-only variations and weird PS quirks
 
 				if [ts[11*(int(line[p])-1)][0],species] not in ts:
 					if species == 'Shaymin' and [ts[11*(int(line[p])-1)][0],'Shaymin-Sky'] in ts:

--- a/batchMovesetCounter.py
+++ b/batchMovesetCounter.py
@@ -29,6 +29,7 @@ def movesetCounter(filename, cutoff, teamtype, usage):
 
 	species = keyLookup[filename[string.rfind(filename,'/')+1:]]
 	species = reverseAliases.get(species, species)
+	speciesKey = keyify(species)
 
 	bias = []
 	stalliness = []
@@ -99,10 +100,10 @@ def movesetCounter(filename, cutoff, teamtype, usage):
 					n=-1
 				else:
 					n=nmod[moveset['nature']][{'atk': 0, 'def': 1, 'spa': 2, 'spd': 3, 'spe': 4}[stat]]
-				x = statFormula(baseStats[keyify(species)][stat],moveset['level'],n,moveset['ivs'][stat],ev)
+				x = statFormula(baseStats[speciesKey][stat],moveset['level'],n,moveset['ivs'][stat],ev)
 
 				while ev > 0:
-					if x != statFormula(baseStats[keyify(species)][stat],moveset['level'],n,moveset['ivs'][stat],ev-1):
+					if x != statFormula(baseStats[speciesKey][stat],moveset['level'],n,moveset['ivs'][stat],ev-1):
 						break
 					ev = ev-1
 			

--- a/batchMovesetCounter.py
+++ b/batchMovesetCounter.py
@@ -12,7 +12,7 @@ import gzip
 import os
 import math
 
-from common import keyify,weighting,readTable,aliases,victoryChance
+from common import keyify,weighting,readTable,reverseAliases,victoryChance
 from TA import nmod,statFormula,baseStats
 
 def movesetCounter(filename, cutoff, teamtype, usage):
@@ -28,10 +28,7 @@ def movesetCounter(filename, cutoff, teamtype, usage):
 			raw[i]=raw[i]+']'
 
 	species = keyLookup[filename[string.rfind(filename,'/')+1:]]
-	for alias in aliases:
-		if species in aliases[alias]:
-			species = alias
-			break
+	species = reverseAliases.get(species, species)
 
 	bias = []
 	stalliness = []

--- a/common.py
+++ b/common.py
@@ -199,6 +199,8 @@ aliases={
 	'Terapagos': ['Terapagos-Terastal', 'Terapagosterastal', 'Terapagos-Stellar', 'Terapagosstellar']
 }
 
+reverseAliases = {alias: species for species, aliasList in aliases.items() for alias in aliasList}
+
 nonSinglesFormats = [
 	'battlespotdoubles',
 	'battlespottriples',

--- a/common.py
+++ b/common.py
@@ -5,15 +5,11 @@ import math
 import js2py
 import urllib2
 import ujson as json
+import re
 
+nonKeyRegex = re.compile('[^a-z0-9]+')
 def keyify(s):
-	sout = ''
-	for c in s:
-		if c in string.uppercase:
-			sout = sout + c.lower()
-		elif c in string.lowercase + '1234567890':
-			sout = sout + c
-	return sout
+	return nonKeyRegex.sub('', s.lower())
 
 #our weighting function
 def weighting(rating,deviation,cutoff):


### PR DESCRIPTION
Some simple changes to hot code.

---

Tested/benchmarked on 30k gen9randbats generated with PokeEnv.

python 2.7.18
python 3.10.12 for `py3` (`shrianshChari`'s PR)

time in seconds

| script | baseline py2 | py3 | this py2 | this + py3 |
| --- | --- | --- | --- | --- |
| batchLogReader | 238 | 166 | 154 | 135 |
| StatCounter | 69 | 16 | 54 | 10 |
| batchMovesetCounter | 40.8 | 17 | 16.8 | 8 |

---

This did have some merge conflicts with the py3 PR, but they're very straightforward. If you merge the py3 PR first, I can just resolve the conflicts on this branch.

---

I had the two changes as separate PRs initially, but that results in another merge conflict, and the changes are dead simple anyway.

---

I believe newer versions of Python are even ""faster"", so that's another thing to look forward to.