### PR TITLE
Downgrade Python to remove errors with Js2py

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: sus-env3
 dependencies:
 - ipython
-- python=3.12
+- python=3.11
 - pip
 - js2py


### PR DESCRIPTION
When using Python 3.12 with `js2py`, it will produce a `KeyError` when attempting to import the package. Considering we don't use any of the new features in 3.12, I think we should downgrade the version of Python we use to make the scripts runnable again.